### PR TITLE
Remove Slack Notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,3 @@ jdk:
 # Karaf 2.3.x does not support Java 8
 # https://issues.apache.org/jira/browse/KARAF-2602
 #  - oraclejdk8
-notifications:
-  slack: connexta:81WapNypxEStYlHEnsrCml7n


### PR DESCRIPTION
I've removed the configuration to notify our slack channel when your build completes. See issue #1

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nehaknp/travelsample/2)

<!-- Reviewable:end -->
